### PR TITLE
Allow passing a job-specific logging configuration

### DIFF
--- a/camus-api/pom.xml
+++ b/camus-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
   </parent>
 
   <artifactId>camus-api</artifactId>

--- a/camus-etl-kafka/pom.xml
+++ b/camus-etl-kafka/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
   </parent>
 
   <artifactId>camus-etl-kafka</artifactId>

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
@@ -252,8 +252,8 @@ public class CamusJob extends Configured implements Tool {
         return job.getConfiguration().getInt(KAFKA_FETCH_BUFFER_SIZE, 1024 * 1024);
     }
 
-    public static boolean getLog4jConfigure(JobContext job) {
-        return job.getConfiguration().getBoolean(LOG4J_CONFIGURATION, false);
+    public static String getLog4jConfigure(JobContext job) {
+        return job.getConfiguration().get(LOG4J_CONFIGURATION);
     }
 
     public static String getReporterClass(JobContext job) {
@@ -304,8 +304,8 @@ public class CamusJob extends Configured implements Tool {
         EmailClient.setup(props);
 
         Job job = createJob(props);
-        if (getLog4jConfigure(job)) {
-            DOMConfigurator.configure("log4j.xml");
+        if (getLog4jConfigure(job) != null) {
+            DOMConfigurator.configure(getLog4jConfigure(job));
         }
         FileSystem fs = FileSystem.get(job.getConfiguration());
 

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/workallocater/BaseAllocator.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/workallocater/BaseAllocator.java
@@ -47,8 +47,8 @@ public class BaseAllocator extends WorkAllocator {
 
         List<InputSplit> kafkaETLSplits = new ArrayList<>();
 
-        for (int i = 0; i < numTasks; i++) {
-            if (requests.size() > 0) {
+        if (requests.size() > 0) {
+            for (int i = 0; i < numTasks; i++) {
                 kafkaETLSplits.add(new EtlSplit());
             }
         }

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/workallocater/TopicGroupingAllocator.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/workallocater/TopicGroupingAllocator.java
@@ -29,8 +29,8 @@ public class TopicGroupingAllocator extends BaseAllocator {
         int numTasks = context.getConfiguration().getInt("mapred.map.tasks", 30);
         List<InputSplit> kafkaETLSplits = new ArrayList<>();
 
-        for (int i = 0; i < numTasks; i++) {
-            if (requests.size() > 0) {
+        if (requests.size() > 0) {
+            for (int i = 0; i < numTasks; i++) {
                 kafkaETLSplits.add(new EtlSplit());
             }
         }

--- a/camus-kafka-coders/pom.xml
+++ b/camus-kafka-coders/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
   </parent>
 
   <artifactId>camus-kafka-coders</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,19 +52,19 @@
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-mapreduce-client-core</artifactId>
-        <version>2.6.0-cdh5.8.4</version>
+        <version>2.6.0</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-mapreduce-client-common</artifactId>
-        <version>2.6.0-cdh5.8.4</version>
+        <version>2.6.0</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-common</artifactId>
-        <version>2.6.0-cdh5.8.4</version>
+        <version>2.6.0</version>
         <scope>provided</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.linkedin.camus</groupId>
   <artifactId>camus-parent</artifactId>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <packaging>pom</packaging>
   <name>Camus Parent</name>
   <description>


### PR DESCRIPTION
106433e allows pointing to a `log4j` configuration in order to, e.g., have a dedicated log file for each camus job. When all jobs are logging to the same log file the log stream becomes unreadable. 



