### PR TITLE
Improvements for mappers processing multiple partitions.

### DIFF
--- a/camus-api/pom.xml
+++ b/camus-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
   </parent>
 
   <artifactId>camus-api</artifactId>

--- a/camus-api/src/main/java/com/linkedin/camus/workallocater/CamusRequest.java
+++ b/camus-api/src/main/java/com/linkedin/camus/workallocater/CamusRequest.java
@@ -57,12 +57,4 @@ public interface CamusRequest extends Writable {
 
     void setAvgMsgSize(long size);
 
-    /**
-     * Estimates the request size in bytes by connecting to the broker and
-     * querying for the offset that bets matches the endTime.
-     *
-     * @param endTime The time in millisec
-     */
-    long estimateDataSize(long endTime);
-
 }

--- a/camus-etl-kafka/pom.xml
+++ b/camus-etl-kafka/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
   </parent>
 
   <artifactId>camus-etl-kafka</artifactId>

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/EmailClient.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/EmailClient.java
@@ -88,7 +88,7 @@ public class EmailClient {
             }
             message.setSubject(subjectLine);
 
-            message.setContent(content, "text/html");
+            message.setContent(content, "text/plain");
             Transport.send(message);
         } catch (Exception exception) {
             LOGGER.warn("Could not send requested email. Message: " + content, exception);

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/EtlRequest.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/EtlRequest.java
@@ -302,15 +302,6 @@ public class EtlRequest implements CamusRequest {
         return (endOffset - offset) * avgMsgSize;
     }
 
-    /* (non-Javadoc)
-     * @see com.linkedin.camus.etl.kafka.common.CamusRequest#estimateDataSize(long)
-     */
-    @Override
-    public long estimateDataSize(long endTime) {
-        long endOffset = getLastOffset(endTime);
-        return (endOffset - offset) * avgMsgSize;
-    }
-
     @Override
     public void readFields(DataInput in) throws IOException {
         topic = UTF8.readString(in);

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
@@ -490,10 +490,13 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
                 }
             } else if (3 * (request.getOffset() - request.getEarliestOffset())
                        < request.getLastOffset() - request.getOffset()) {
-                camusRequestEmailMessage
-                        .append("The current offset is too close to the earliest offset, Camus might be falling behind: ")
-                        .append(request)
-                        .append("\n");
+
+                if(Strings.isNullOrEmpty(camusRequestEmailMessage.toString())) {
+                    camusRequestEmailMessage.append("The current offset is too close to the earliest offset," +
+                            " Camus might be falling behind:\n\n");
+                }
+
+                camusRequestEmailMessage.append(request).append("\n");
             }
             log.info(request);
         }

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
@@ -481,12 +481,7 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
         // Get the latest offsets and generate the EtlRequests
         finalRequests = fetchLatestOffsetAndCreateEtlRequests(context, offsetRequestInfo);
 
-        Collections.sort(finalRequests, new Comparator<CamusRequest>() {
-            @Override
-            public int compare(CamusRequest r1, CamusRequest r2) {
-                return r1.getTopic().compareTo(r2.getTopic());
-            }
-        });
+        finalRequests.sort(Comparator.comparing(CamusRequest::getTopic));
 
         writeRequests(finalRequests, context);
         Map<CamusRequest, EtlKey> offsetKeys = getPreviousOffsets(

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
@@ -66,9 +66,6 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
     public static final String KAFKA_MOVE_TO_LAST_OFFSET_LIST = "kafka.move.to.last.offset.list";
     public static final String KAFKA_MOVE_TO_EARLIEST_OFFSET = "kafka.move.to.earliest.offset";
 
-    public static final String KAFKA_CLIENT_BUFFER_SIZE = "kafka.client.buffer.size";
-    public static final String KAFKA_CLIENT_SO_TIMEOUT = "kafka.client.so.timeout";
-
     public static final String KAFKA_MAX_PULL_HRS = "kafka.max.pull.hrs";
     public static final String KAFKA_MAX_PULL_MINUTES_PER_TASK = "kafka.max.pull.minutes.per.task";
     public static final String KAFKA_MAX_HISTORICAL_DAYS = "kafka.max.historical.days";
@@ -100,10 +97,6 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
         EtlInputFormat.log = log;
     }
 
-    public static void setWorkAllocator(JobContext job, Class<WorkAllocator> val) {
-        job.getConfiguration().setClass(CAMUS_WORK_ALLOCATOR_CLASS, val, WorkAllocator.class);
-    }
-
     public static WorkAllocator getWorkAllocator(JobContext job) {
         try {
             return (WorkAllocator) job.getConfiguration().getClass(
@@ -114,90 +107,37 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
         }
     }
 
-    public static void setMoveToLatestTopics(JobContext job, String val) {
-        job.getConfiguration().set(KAFKA_MOVE_TO_LAST_OFFSET_LIST, val);
-    }
-
     public static String[] getMoveToLatestTopics(JobContext job) {
         return job.getConfiguration().getStrings(KAFKA_MOVE_TO_LAST_OFFSET_LIST);
-    }
-
-    public static void setKafkaClientBufferSize(JobContext job, int val) {
-        job.getConfiguration().setInt(KAFKA_CLIENT_BUFFER_SIZE, val);
-    }
-
-    public static int getKafkaClientBufferSize(JobContext job) {
-        return job.getConfiguration().getInt(KAFKA_CLIENT_BUFFER_SIZE, 2 * 1024 * 1024);
-    }
-
-    public static void setKafkaClientTimeout(JobContext job, int val) {
-        job.getConfiguration().setInt(KAFKA_CLIENT_SO_TIMEOUT, val);
-    }
-
-    public static int getKafkaClientTimeout(JobContext job) {
-        return job.getConfiguration().getInt(KAFKA_CLIENT_SO_TIMEOUT, 60000);
-    }
-
-    public static void setKafkaMaxPullHrs(JobContext job, int val) {
-        job.getConfiguration().setInt(KAFKA_MAX_PULL_HRS, val);
     }
 
     public static int getKafkaMaxPullHrs(JobContext job) {
         return job.getConfiguration().getInt(KAFKA_MAX_PULL_HRS, -1);
     }
 
-    public static void setKafkaMaxPullMinutesPerTask(JobContext job, int val) {
-        job.getConfiguration().setInt(KAFKA_MAX_PULL_MINUTES_PER_TASK, val);
-    }
-
     public static int getKafkaMaxPullMinutesPerTask(JobContext job) {
         return job.getConfiguration().getInt(KAFKA_MAX_PULL_MINUTES_PER_TASK, -1);
-    }
-
-    public static void setKafkaMaxHistoricalDays(JobContext job, int val) {
-        job.getConfiguration().setInt(KAFKA_MAX_HISTORICAL_DAYS, val);
     }
 
     public static int getKafkaMaxHistoricalDays(JobContext job) {
         return job.getConfiguration().getInt(KAFKA_MAX_HISTORICAL_DAYS, -1);
     }
 
-    public static void setKafkaBlacklistTopic(JobContext job, String val) {
-        job.getConfiguration().set(KAFKA_BLACKLIST_TOPIC, val);
-    }
-
     public static Collection<String> getKafkaBlacklistTopic(JobContext job) {
         return job.getConfiguration().getStringCollection(KAFKA_BLACKLIST_TOPIC);
-    }
-
-    public static void setKafkaWhitelistTopic(JobContext job, String val) {
-        job.getConfiguration().set(KAFKA_WHITELIST_TOPIC, val);
     }
 
     public static Collection<String> getKafkaWhitelistTopic(JobContext job) {
         return job.getConfiguration().getStringCollection(KAFKA_WHITELIST_TOPIC);
     }
 
-    public static void setEtlIgnoreSchemaErrors(JobContext job, boolean val) {
-        job.getConfiguration().setBoolean(ETL_IGNORE_SCHEMA_ERRORS, val);
-    }
-
     public static boolean getEtlIgnoreSchemaErrors(JobContext job) {
         return job.getConfiguration().getBoolean(ETL_IGNORE_SCHEMA_ERRORS, false);
-    }
-
-    public static void setEtlAuditIgnoreServiceTopicList(JobContext job, String topics) {
-        job.getConfiguration().set(ETL_AUDIT_IGNORE_SERVICE_TOPIC_LIST, topics);
     }
 
     public static String[] getEtlAuditIgnoreServiceTopicList(JobContext job) {
         return job.getConfiguration().getStrings(ETL_AUDIT_IGNORE_SERVICE_TOPIC_LIST, "");
     }
-
-    public static void setMessageDecoderClass(JobContext job, Class<MessageDecoder> cls) {
-        job.getConfiguration().setClass(CAMUS_MESSAGE_DECODER_CLASS, cls, MessageDecoder.class);
-    }
-
 
     @SuppressWarnings("unchecked")
     public static Class<MessageDecoder> getMessageDecoderClass(JobContext job) {

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
@@ -427,7 +427,7 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
         Map<CamusRequest, EtlKey> offsetKeys = getPreviousOffsets(
                 FileInputFormat.getInputPaths(context), context);
         Set<String> moveLatest = getMoveToLatestTopicsSet(context);
-        String camusRequestEmailMessage = "";
+        StringBuilder camusRequestEmailMessage = new StringBuilder();
         for (CamusRequest request : finalRequests) {
             if (moveLatest.contains(request.getTopic()) || moveLatest.contains("all")) {
                 log.info("Moving to latest for topic: " + request.getTopic());
@@ -490,14 +490,15 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
                 }
             } else if (3 * (request.getOffset() - request.getEarliestOffset())
                        < request.getLastOffset() - request.getOffset()) {
-                camusRequestEmailMessage +=
-                        "The current offset is too close to the earliest offset, Camus might be falling behind: "
-                        + request + "\n";
+                camusRequestEmailMessage
+                        .append("The current offset is too close to the earliest offset, Camus might be falling behind: ")
+                        .append(request)
+                        .append("\n");
             }
             log.info(request);
         }
-        if (!Strings.isNullOrEmpty(camusRequestEmailMessage)) {
-            EmailClient.sendEmail(camusRequestEmailMessage);
+        if (camusRequestEmailMessage.length() > 0) {
+            EmailClient.sendEmail(camusRequestEmailMessage.toString());
         }
 
         writePrevious(offsetKeys.values(), context);

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
@@ -37,7 +37,7 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
 
     private final EtlKey key = new EtlKey();
     protected TaskAttemptContext context;
-    EtlSplit split;
+    private EtlSplit split;
     private final EtlInputFormat inputFormat;
     private Mapper<EtlKey, Writable, EtlKey, Writable>.Context mapperContext;
     private KafkaReader reader;
@@ -362,7 +362,7 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
         }
     }
 
-    public void setServerService() {
+    private void setServerService() {
         if (ignoreServerServiceList.contains(key.getTopic()) || ignoreServerServiceList
                 .contains("all")) {
             key.setServer(DEFAULT_SERVER);

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
@@ -32,7 +32,6 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
     private static final String PRINT_MAX_DECODER_EXCEPTIONS = "max.decoder.exceptions.to.print";
     private static final String DEFAULT_SERVER = "server";
     private static final String DEFAULT_SERVICE = "service";
-    private static final int RECORDS_TO_READ_AFTER_TIMEOUT = 5;
     private static final Logger log = Logger.getLogger(EtlRecordReader.class);
 
     private final EtlKey key = new EtlKey();
@@ -180,8 +179,7 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
     @Override
     public boolean nextKeyValue() throws IOException, InterruptedException {
 
-        if (System.currentTimeMillis() > maxPullTime
-            && numRecordsReadForCurrentPartition >= RECORDS_TO_READ_AFTER_TIMEOUT) {
+        if (System.currentTimeMillis() > maxPullTime) {
             String maxMsg = "at " + new DateTime(curTimeStamp).toString();
             log.info("Kafka pull time limit reached");
             statusMsg.append(" max read ").append(maxMsg);

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
@@ -198,7 +198,7 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
 
             logPartitionSummary();
 
-            reader = null;
+            return false;
         }
 
         while (true) {

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
@@ -233,10 +233,7 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
                             request.getOffset(),
                             request.getOffset(), 0);
                     value = null;
-                    log.info("\n\ntopic:" + request.getTopic() + " partition:" + request
-                            .getPartition() + " beginOffset:"
-                             + request.getOffset() + " estimatedLastOffset:" + request
-                                     .getLastOffset());
+                    log.info("\n\nProcessing request: " + request);
                     statusMsg.append(statusMsg.length() > 0 ? "; " : "");
                     statusMsg.append(request.getTopic()).append(":").append(request.getLeaderId())
                             .append(":").append(request.getPartition());

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlSplit.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlSplit.java
@@ -17,7 +17,10 @@ import java.util.Queue;
 public class EtlSplit extends InputSplit implements Writable {
 
     // Sort by topic, so that requests from the same topic are processed after each other
-    private final Comparator<CamusRequest> priorityComparator = Comparator.comparing(CamusRequest::getTopic);
+    // Then reverse sort by size, so that the biggest request are processed first, so that
+    // partitions which are lagging mostly behind are processed with priority.
+    private final Comparator<CamusRequest> priorityComparator = Comparator.comparing(CamusRequest::getTopic)
+            .thenComparing(CamusRequest::estimateDataSize, Comparator.reverseOrder());
 
     private final Queue<CamusRequest> requests = new PriorityQueue<>(5, priorityComparator);
     private long length = 0;

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlSplit.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlSplit.java
@@ -25,8 +25,7 @@ public class EtlSplit extends InputSplit implements Writable {
         for (int i = 0; i < size; i++) {
             CamusRequest r = new EtlRequest();
             r.readFields(in);
-            requests.add(r);
-            length += r.estimateDataSize();
+            addRequest(r);
         }
     }
 

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/workallocater/BaseAllocator.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/workallocater/BaseAllocator.java
@@ -7,8 +7,6 @@ import org.apache.hadoop.mapreduce.JobContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Properties;
 
@@ -21,29 +19,12 @@ public class BaseAllocator extends WorkAllocator {
         this.props = props;
     }
 
-    protected void reverseSortRequests(List<CamusRequest> requests) {
-        // Reverse sort by size
-        Collections.sort(requests, new Comparator<CamusRequest>() {
-            @Override
-            public int compare(CamusRequest o1, CamusRequest o2) {
-                if (o2.estimateDataSize() == o1.estimateDataSize()) {
-                    return 0;
-                }
-                if (o2.estimateDataSize() < o1.estimateDataSize()) {
-                    return -1;
-                } else {
-                    return 1;
-                }
-            }
-        });
-    }
-
     @Override
     public List<InputSplit> allocateWork(List<CamusRequest> requests, JobContext context)
             throws IOException {
         int numTasks = context.getConfiguration().getInt("mapred.map.tasks", 30);
 
-        reverseSortRequests(requests);
+        requests.sort((r1, r2) -> r1.estimateDataSize() > r2.estimateDataSize() ? -1 : 1); // reverse sort
 
         List<InputSplit> kafkaETLSplits = new ArrayList<>();
 

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/workallocater/TopicGroupingAllocator.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/workallocater/TopicGroupingAllocator.java
@@ -192,11 +192,6 @@ public class TopicGroupingAllocator extends BaseAllocator {
         }
 
         @Override
-        public long estimateDataSize(long endTime) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
         public Iterator<CamusRequest> iterator() {
             return requests.iterator();
         }

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/workallocater/TopicGroupingAllocator.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/workallocater/TopicGroupingAllocator.java
@@ -52,9 +52,7 @@ public class TopicGroupingAllocator extends BaseAllocator {
     private List<CamusRequest> groupSmallRequest(List<CamusRequest> requests, JobContext context) {
         List<CamusRequest> finalRequests = new ArrayList<>();
 
-        Map<String, List<CamusRequest>>
-                requestsTopicMap
-                = new HashMap<>();
+        Map<String, List<CamusRequest>> requestsTopicMap = new HashMap<>();
         long totalEstimatedDataSize = 0;
 
         for (CamusRequest cr : requests) {

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/workallocater/TopicGroupingAllocator.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/workallocater/TopicGroupingAllocator.java
@@ -37,7 +37,7 @@ public class TopicGroupingAllocator extends BaseAllocator {
 
         List<CamusRequest> groupedRequests = groupSmallRequest(requests, context);
 
-        reverseSortRequests(groupedRequests);
+        groupedRequests.sort((r1, r2) -> r1.estimateDataSize() > r2.estimateDataSize() ? -1 : 1); // reverse sort
 
         for (CamusRequest r : groupedRequests) {
             EtlSplit split = getSmallestMultiSplit(kafkaETLSplits);

--- a/camus-kafka-coders/pom.xml
+++ b/camus-kafka-coders/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
   </parent>
 
   <artifactId>camus-kafka-coders</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.linkedin.camus</groupId>
   <artifactId>camus-parent</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
   <packaging>pom</packaging>
   <name>Camus Parent</name>
   <description>


### PR DESCRIPTION
Only last 3-4 commits are essential. They address problems with jobs which have tasks processing multiple partitions:
* 2c10176 - Fixes a problem where after `kafka.max.pull.minutes.per.task` passes, tasks still process a small chunk of remaining partitions. This not only additionally exceeds that timeout, but also results in very small files being created for those additional partitions.
* eae6fae - Previously, a task was arbitrarily picking a partition to process next. This becomes a problem e.g. when jobs start lagging behind and it is important to first process partitions which are lagging mostly behind. 




