### PR TITLE
Bump version to 1.0.7 and fix surefire plugin.

### DIFF
--- a/camus-api/pom.xml
+++ b/camus-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
   </parent>
 
   <artifactId>camus-api</artifactId>

--- a/camus-etl-kafka/pom.xml
+++ b/camus-etl-kafka/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
   </parent>
 
   <artifactId>camus-etl-kafka</artifactId>

--- a/camus-kafka-coders/pom.xml
+++ b/camus-kafka-coders/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
   </parent>
 
   <artifactId>camus-kafka-coders</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.linkedin.camus</groupId>
   <artifactId>camus-parent</artifactId>
-  <version>1.0.6</version>
+  <version>1.0.7</version>
   <packaging>pom</packaging>
   <name>Camus Parent</name>
   <description>
@@ -177,9 +177,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.12.4</version>
+        <version>2.22.1</version>
         <configuration>
           <argLine>-Djava.awt.headless=true</argLine>
+          <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
While trying to deploy #8 I noticed some problems with the surefire plugin and also with the version 1.0.6. I had to change both to get the PR to work smoothly. Please also see the commit message for further information.