### PR TITLE
Throw close exception.

### DIFF
--- a/camus-api/pom.xml
+++ b/camus-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
   </parent>
 
   <artifactId>camus-api</artifactId>

--- a/camus-etl-kafka/pom.xml
+++ b/camus-etl-kafka/pom.xml
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>15.0</version>
+      <version>27.1-jre</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/camus-etl-kafka/pom.xml
+++ b/camus-etl-kafka/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
   </parent>
 
   <artifactId>camus-etl-kafka</artifactId>

--- a/camus-kafka-coders/pom.xml
+++ b/camus-kafka-coders/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
   </parent>
 
   <artifactId>camus-kafka-coders</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.linkedin.camus</groupId>
   <artifactId>camus-parent</artifactId>
-  <version>1.0.7</version>
+  <version>1.0.8</version>
   <packaging>pom</packaging>
   <name>Camus Parent</name>
   <description>


### PR DESCRIPTION
This should fix the bug of having corrupted and incomplete files end up in HDFS. 

**Explanation** 

In situations of high load Yarn sometimes looses connection to the DataNodes. This leads to an internal exception:
```
java.io.EOFException: Premature EOF: no length prefix available
	at org.apache.hadoop.hdfs.protocolPB.PBHelper.vintPrefixed(PBHelper.java:2307)
	at org.apache.hadoop.hdfs.protocol.datatransfer.PipelineAck.readFields(PipelineAck.java:235)
	at org.apache.hadoop.hdfs.DFSOutputStream$DataStreamer$ResponseProcessor.run(DFSOutputStream.java:1093)
```

Internal error handling of Hadoop OutputStream work the way that exceptions are collected until `flush` or `close` are called. Then the last exception is thrown. 

Unfotunately Camus uses a Guava cache to store its RecordWriters and uses the caches removal mechanism for closing. But from this listener interface you can't throw an IOException and so they're just logging the exception and that's it. 🙈 

This PR caches the exception now in the RemovalListener and throws it from the output formats close method if it's not null.

